### PR TITLE
Bug/issue 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Running `acme pull` "pulls" generated component markup, referenced images, js an
    All component policies are saved here as `json` files. These policies are referenced in the respective component stories to optionally apply any defined style system.
 
 4. `resources`
-   This directory contains the `clientlib-base` js and css files as well as any other resources defined on the page. For example, the sample project references `https://use.fontawesome.com/db86937673.js` to load icons.
+   This directory contains the `clientlib-base` js and css which includes the AEM Core Component client libraries as well as AEM Grid. Any other resources defined on the page are also included. For example, the sample project references `https://use.fontawesome.com/db86937673.js` to load icons.
 
 `acme create` generates stories for each component variation under the `components` directory of the source directory defined by `--source` or `-s` option. The source directory would be the same as the destination directory in the `pull` command. The following assets are created:
 
 1. `stories`
    Contains `.stories.js` files for each component. Each file in turn contains individual stories for that component.
 
-2. `.storybook\preview-head.html`
-   This file is purely for any static dependencies to render the components in Storybook correctly. For example, if your component is based on an AEM Core Component, it would depend on the core component js and css files. These dependencies are compiled into `clientlib-base.js` and `clientlib-base.css`. The `preview-head.html` would then contain script and link tags referencing these files downloaded by the `pull` command into the `resources` directory. Any other downloaded resource would also be included in this file.
+2. `.storybook/preview.js`
+   This file imports the assets added to the `resources` directory as well as the entry point to the webpack application at `/src/main/webpack/site/main.ts`--this enables storybook to render the components with the default CSS and JavaScript from the AEM Core Components along with your own custom CSS and JavaScript.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@hoodoo/acme",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/_templates/preview/new/preview.ejs.t
+++ b/src/_templates/preview/new/preview.ejs.t
@@ -1,13 +1,10 @@
 ---
-to: .storybook/preview-head.html
+to: .storybook/preview.js
 ---
 <%_
     const resources = resourceList.split(',')
     for (let resource of resources) {
-        if (resource.endsWith('.css')) {
-        _%><link rel="stylesheet" href="<%= resource %>">
-    <%_ } else if (resource.endsWith('.js')) {
-            _%><script src="<%= resource %>"></script>
-    <%_ }
-    }
+        _%>import '<%= resource %>';
+    <%_}
+    _%>import '../src/main/webpack/site/main.ts';<%_
 _%>

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,4 +1,4 @@
-const { createStories, generatePreviewHeadHtml } = require('../create')
+const { createStories, generatePreviewJS } = require('../create')
 
 module.exports = {
     command: 'create',
@@ -13,6 +13,6 @@ module.exports = {
     },
     handler: (argv) => {
         createStories(argv.source)
-        generatePreviewHeadHtml(argv.source)
+        generatePreviewJS(argv.source)
     }
 }

--- a/src/create.js
+++ b/src/create.js
@@ -99,7 +99,7 @@ const generatePreviewJS = async (assetsPath) => {
     const resourcesRelPath = resources.map((resource) => {
         return path.join(
             '..',
-            +path.sep,
+            path.sep,
             assetsPath,
             'resources',
             resource.name

--- a/src/create.js
+++ b/src/create.js
@@ -20,8 +20,10 @@ const execOptions = {
 const createStories = async (assetsPath) => {
     const componentsPath = path.join(assetsPath, 'components')
     // Path relative to assetsPath
-    const policiesRelPath = path.sep + 'policies'
-    const componentsRelPath = path.sep + 'components'
+    const policiesRelPath =
+        '..' + path.sep + assetsPath + path.sep + 'policies'
+    const componentsRelPath =
+        '..' + path.sep + assetsPath + path.sep + 'components'
     const components = await fs.promises.readdir(componentsPath, {
         withFileTypes: true
     })
@@ -95,7 +97,13 @@ const generatePreviewJS = async (assetsPath) => {
         withFileTypes: true
     })
     const resourcesRelPath = resources.map((resource) => {
-        return path.join('../', assetsPath, 'resources', resource.name)
+        return path.join(
+            '..',
+            +path.sep,
+            assetsPath,
+            'resources',
+            resource.name
+        )
     })
     log('Generating preview.js file')
     await execa(

--- a/src/create.js
+++ b/src/create.js
@@ -89,15 +89,15 @@ const createStories = async (assetsPath) => {
     }
 }
 
-const generatePreviewHeadHtml = async (assetsPath) => {
+const generatePreviewJS = async (assetsPath) => {
     const resourcesPath = path.join(assetsPath, 'resources')
     const resources = await fs.promises.readdir(resourcesPath, {
         withFileTypes: true
     })
     const resourcesRelPath = resources.map((resource) => {
-        return path.sep + path.join('resources', resource.name)
+        return path.join('../', assetsPath, 'resources', resource.name)
     })
-    log('Generating preview-head.html file')
+    log('Generating preview.js file')
     await execa(
         'npx',
         [
@@ -114,4 +114,4 @@ const generatePreviewHeadHtml = async (assetsPath) => {
 
 // createStories(argv.path).catch(console.error)
 exports.createStories = createStories
-exports.generatePreviewHeadHtml = generatePreviewHeadHtml
+exports.generatePreviewJS = generatePreviewJS


### PR DESCRIPTION
closes #29 
closes #30 

## Details

- What I did
Changed the resources added to `preview-head.html` to instead be added to `preview.js`
Fixed resources, component, and policy paths which were not resolving

- How to test
Run acme in a sample project. Components, policies, base styles, and custom styles should all load correctly

- Does this change require an update to the documentation?
Yes, updated readme as part of this PR

Include answers to these questions and any other relevant details
I hardcoded the entry point to the webpack application `/src/main/webpack/site/main.ts`. This matches the setup in the AEM archetype but we may want to add this to the settings config to allow for customization.

