### PR TITLE
update how aemMetadata is set

### DIFF
--- a/src/_templates/stories/new/stories.ejs.t
+++ b/src/_templates/stories/new/stories.ejs.t
@@ -10,12 +10,7 @@ import { acmeFetch, getArtboardUrl } from '@hoodoo/acme';
 export default {
   title: '<%= Name %>',
   decorators: [
-    withXD,
-    aemMetadata({
-      decorationTag: {
-        cssClasses: [StyleSystem]
-      }
-    })
+    withXD
   ],
   parameters: {
     aemStyleSystem: {

--- a/src/_templates/story/new/story.ejs.t
+++ b/src/_templates/story/new/story.ejs.t
@@ -14,7 +14,7 @@ export const <%= funcName%> = () => {
     template: acmeFetch(<%= path %>),
     aemMetadata: {
       decorationTag: {
-        cssClasses: []  // Add css class(es) applicable to this story
+        cssClasses: [StyleSystem]  // Add additional css class(es) applicable to this story as needed
       }
     }
   }


### PR DESCRIPTION
closes #52 

set cssClasses of aemMetadata on individual stories and not in the export default function.

- What I did
updated template files that generate the stories

- How to test
run acme in a project to confirm stories are generated with the correct aemMetadata/cssClasses

- Does this change require an update to the documentation?
no



